### PR TITLE
feat: removed github actions on push | HOLD: In Discussion With AO

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,9 +4,7 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches: [ '*' ]
-  pull_request:
+ pull_request:
     branches: [ '*' ]
 
 jobs:


### PR DESCRIPTION
# Stop Tests On Push

### Issue
Closes [283](https://github.com/Real-Dev-Squad/website-crypto/issues/283)

### Before The Change
- Github workflow `node.js.yml` run tests on events `push` and `pr`

### After The Change
- Github workflow `node.js.yml` will run tests on event `pr` only

